### PR TITLE
fix(vite): Use relative paths for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 export default defineConfig(() => ({
-  server: { host: "::", port: 8080 },
+  server: { host: "localhost", port: 8080 },
   plugins: [react()],
   resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
-  base: "/", // ← important for user sites on GitHub Pages
+  base: "./", // ← important for user sites on GitHub Pages
 }));


### PR DESCRIPTION
Changed the `base` property in `vite.config.ts` from `"/"` to `"./"`.

This ensures that asset paths in the built `index.html` are relative, which is necessary for correct deployment to GitHub Pages with a custom domain. This resolves the "Failed to load module script" MIME type error that occurs when using absolute paths.

Also updated the dev server host to 'localhost' to prevent startup errors in environments that do not support the IPv6 '::' address.